### PR TITLE
ci: bump used version of helm-unittest-action

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -17,3 +17,5 @@ jobs:
 
       - name: Run unit tests
         uses: d3adb5/helm-unittest-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -16,4 +16,4 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run unit tests
-        uses: d3adb5/helm-unittest-action@v1
+        uses: d3adb5/helm-unittest-action@v2


### PR DESCRIPTION
Bump the version used in this repository of the helm-unittest-action reusable action, from v1 to v2, to ensure we're using the latest version of the helm-unittest plugin.
